### PR TITLE
Remove trailing commas in function attributes as it was causing a fatal server error for some PHP versions

### DIFF
--- a/blocks/accordion-item.php
+++ b/blocks/accordion-item.php
@@ -23,8 +23,8 @@ function accordion_toggle_accordion_item_block_init()
 
     if (!WP_Block_Type_Registry::get_instance()->is_registered('essential-blocks/accordion')) {
         register_block_type(
-            Accordion_Helper::get_block_register_path("accordion-item"),
+            Accordion_Helper::get_block_register_path("accordion-item")
         );
     }
 }
-add_action('init', 'accordion_toggle_accordion_item_block_init',);
+add_action('init', 'accordion_toggle_accordion_item_block_init');


### PR DESCRIPTION
Please see https://github.com/EssentialBlocks/accordion-toggle/issues/17 and https://wordpress.org/support/topic/proposed-bug-fix-version-1-2-4-fatal-server-error/ for more details.